### PR TITLE
なぜclient got end-of-streamが出るか調査

### DIFF
--- a/connectPython.pde
+++ b/connectPython.pde
@@ -14,18 +14,12 @@ void setup() {
 }
 
 void draw() {
-  try{
-    Client client = server.available();
-  
-    if (client !=null) {
-      String whatClientSaid = client.readString();
-      if (whatClientSaid != null) {
-        println(whatClientSaid); 
-      }
+  Client client = server.available();
+
+  if (client !=null) {
+    String whatClientSaid = client.readString();
+    if (whatClientSaid != null) {
+      println(whatClientSaid); 
     }
-    
-  }catch(Exception e){
-    exit();
   }
- 
 }

--- a/toProcessing_yama.py
+++ b/toProcessing_yama.py
@@ -1,0 +1,14 @@
+import socket
+import time
+
+host = "127.0.0.1" #Processingで立ち上げたサーバのIPアドレス
+port = 10001       #Processingで設定したポート番号
+
+if __name__ == '__main__':
+    socket_client = socket.socket(socket.AF_INET, socket.SOCK_STREAM) #オブジェクトの作成
+    socket_client.connect((host, port))                               #サーバに接続
+
+    #socket_client.send('送信するメッセージ')                #データを送信 Python2
+    while True:
+      socket_client.send('hello world'.encode('utf-8')) #データを送信 Python3
+      time.sleep(5);


### PR DESCRIPTION
なぜclient got end-of-streamが出るか調査してみました。

client got end-of-streamは特に例外エラーでは無いようです。
多分クライアント(python)側からのソケット切断のタイミングでinputStreamが終わったよと
言うのをただコンソール出力しているようです(赤文字で出してほしくないけど)。

テスト用のtoProcessing.pyをコピーして無限ループで動きつつけるプログラムを作ってみたらプログラムが動いている間は
client got end-of-streamでませんでした。

connectPython.pdeは例外処理意味ないみたいだったのでtry-catch消しました。